### PR TITLE
Exiting after import and export

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,10 +31,12 @@ if (argv.location) console.log('mocknode installation directory: ', __dirname);e
   fse.copySync(__dirname + '/config.json', tmp_path + '/config.json');
   tar.pack(tmp_path).pipe(fs.createWriteStream('mocknode-config.tar'));
   console.log('mocknode config has been exported to mocknode-config.tar');
+  process.exit(0);
 } else if (argv.import) {
   var _tar = require('tar-fs');
   fs.createReadStream(argv.import).pipe(_tar.extract(__dirname));
   console.log('configuration has been imported');
+  process.exit(0);
 } else {
   (function () {
 
@@ -500,4 +502,3 @@ if (argv.location) console.log('mocknode installation directory: ', __dirname);e
     // App ends
   })();
 }
-

--- a/src/server.es6
+++ b/src/server.es6
@@ -33,10 +33,12 @@ else if (argv.export) {
   fse.copySync(__dirname + '/config.json', tmp_path + '/config.json');
   tar.pack(tmp_path).pipe(fs.createWriteStream('mocknode-config.tar'));
   console.log('mocknode config has been exported to mocknode-config.tar');
+  process.exit(0);
 } else if (argv.import) {
   let tar = require('tar-fs');
   fs.createReadStream(argv.import).pipe(tar.extract(__dirname));
   console.log('configuration has been imported');
+  process.exit(0);
 } else {
 
 // App starts


### PR DESCRIPTION
I added process.exit after both export and import so that I can add --import to node pretest